### PR TITLE
handle root element, and fix stack level too deep

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -22,8 +22,8 @@ module Replicate
         @replicate_opts = opts
         @replicate_opts[:associations] ||= []
         @replicate_opts[:omit] ||= []
-        dump_all_association_replicants dumper, :belongs_to
         dumper.write self.class.to_s, id, replicant_attributes, self
+        dump_all_association_replicants dumper, :belongs_to
         dump_all_association_replicants dumper, :has_one
         included_associations.each do |association|
           dump_association_replicants dumper, association

--- a/lib/replicate/dumper.rb
+++ b/lib/replicate/dumper.rb
@@ -19,7 +19,7 @@ module Replicate
     # Create a new Dumper.
     #
     # io          - IO object to write marshalled replicant objects to.
-    # root_class  - dump only one item of root class.
+    # root_class  - Dump only one item of root class.
     # block       - Dump context block. If given, the end of the block's execution
     #          is assumed to be the end of the dump stream.
     def initialize(io=nil, root_class=nil)

--- a/lib/replicate/dumper.rb
+++ b/lib/replicate/dumper.rb
@@ -18,11 +18,13 @@ module Replicate
   class Dumper < Emitter
     # Create a new Dumper.
     #
-    # io     - IO object to write marshalled replicant objects to.
-    # block  - Dump context block. If given, the end of the block's execution
+    # io          - IO object to write marshalled replicant objects to.
+    # root_class  - dump only one item of root class.
+    # block       - Dump context block. If given, the end of the block's execution
     #          is assumed to be the end of the dump stream.
-    def initialize(io=nil)
+    def initialize(io=nil, root_class=nil)
       @memo = Hash.new { |hash,k| hash[k] = {} }
+      @root_class = root_class.name if root_class.present?
       super() do
         marshal_to io if io
         yield self if block_given?
@@ -99,6 +101,7 @@ module Replicate
       else
         return false
       end
+      return true if (type.to_s == @root_class) && (@memo[type.to_s].present?)
       @memo[type.to_s][id]
     end
 

--- a/test/dumper_test.rb
+++ b/test/dumper_test.rb
@@ -44,6 +44,23 @@ class DumperTest < Minitest::Test
     assert called
   end
 
+  def test_never_dumps_objects_more_than_once_for_root_class
+    called = false
+    object = thing('name' => 'thing', 'test' => 'value1')
+    object2 = thing('name' => 'thing', 'test' => 'value2')
+    @dumper = Replicate::Dumper.new(nil, Replicate::Object)
+    @dumper.listen do |type, id, attrs, obj|
+      assert !called
+      called = true
+    end
+
+    @dumper.dump object
+    @dumper.dump object
+    @dumper.dump object
+    @dumper.dump object2
+    assert called
+  end
+
   # This test currently fails. It's been a long time since anybody
   # worked on this library and I'm not sure if it's just because of
   # a Ruby update or what. In any event I'm just going to comment it out


### PR DESCRIPTION
Add 2 changes:
1. Infinite loop, incase of internal loop with `has_many` attributed, the `dump?` method are not recognizing the loop, because it is filled after the entity replications. (I added a unit test that reproduced the issue)
I change the order of the replication:

       dumper.write self.class.to_s, id, replicant_attributes, self
       dump_all_association_replicants dumper, :belongs_to
       dump_all_association_replicants dumper, :has_one

2. Root class replication - in my use case there is root entity (Tenant) that used for replication all the entities under the tenant. some times there is cross merchant links (related merchants). when this happen the Gem is replicating the second merchant, which is not needed.