### PR TITLE
remove query cache

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -336,24 +336,6 @@ module Replicate
       end
     end
 
-    # Backport connection.enable_query_cache! for Rails 2.x
-    require 'active_record/connection_adapters/abstract/query_cache'
-    query_cache = ::ActiveRecord::ConnectionAdapters::QueryCache
-    if !query_cache.methods.any? { |m| m.to_sym == :enable_query_cache! }
-      query_cache.module_eval do
-        attr_writer :query_cache, :query_cache_enabled
-
-        def enable_query_cache!
-          @query_cache ||= {}
-          @query_cache_enabled = true
-        end
-
-        def disable_query_cache!
-          @query_cache_enabled = false
-        end
-      end
-    end
-
     # Load active record and install the extension methods.
     ::ActiveRecord::Base.send :include, InstanceMethods
     ::ActiveRecord::Base.send :extend,  ClassMethods

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -590,9 +590,5 @@ class ActiveRecordTest < Minitest::Test
     user = User.find(user.id)
     assert_equal timestamp, user.updated_at
   end
-
-  def test_enabling_active_record_query_cache
-    ActiveRecord::Base.connection.enable_query_cache!
-    ActiveRecord::Base.connection.disable_query_cache!
-  end
+  
 end


### PR DESCRIPTION
Backport for query cache conflicts with rails 6