### PR TITLE
Revert "handle root element, and fix stack level too deep"

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -22,8 +22,8 @@ module Replicate
         @replicate_opts = opts
         @replicate_opts[:associations] ||= []
         @replicate_opts[:omit] ||= []
-        dumper.write self.class.to_s, id, replicant_attributes, self
         dump_all_association_replicants dumper, :belongs_to
+        dumper.write self.class.to_s, id, replicant_attributes, self
         dump_all_association_replicants dumper, :has_one
         included_associations.each do |association|
           dump_association_replicants dumper, association

--- a/lib/replicate/dumper.rb
+++ b/lib/replicate/dumper.rb
@@ -18,13 +18,11 @@ module Replicate
   class Dumper < Emitter
     # Create a new Dumper.
     #
-    # io          - IO object to write marshalled replicant objects to.
-    # root_class  - Dump only one item of root class.
-    # block       - Dump context block. If given, the end of the block's execution
+    # io     - IO object to write marshalled replicant objects to.
+    # block  - Dump context block. If given, the end of the block's execution
     #          is assumed to be the end of the dump stream.
-    def initialize(io=nil, root_class=nil)
+    def initialize(io=nil)
       @memo = Hash.new { |hash,k| hash[k] = {} }
-      @root_class = root_class.name if root_class.present?
       super() do
         marshal_to io if io
         yield self if block_given?
@@ -101,7 +99,6 @@ module Replicate
       else
         return false
       end
-      return true if (type.to_s == @root_class) && (@memo[type.to_s].present?)
       @memo[type.to_s][id]
     end
 

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -19,7 +19,6 @@ ActiveRecord::Schema.define do
     t.string   "login"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "user_id"
   end
 
   create_table "profiles", :force => true do |t|
@@ -55,7 +54,6 @@ end
 
 # models
 class User < ActiveRecord::Base
-  belongs_to :user
   has_one  :profile, :dependent => :destroy
   has_many :emails,  -> { order('id') }, :dependent => :destroy
   has_many :notes,   :as => :notable
@@ -121,7 +119,6 @@ class ActiveRecordTest < Minitest::Test
     user.emails.create! :email => 'kyle@github.com'
 
     user = User.create! :login => 'tmm1'
-    user.update(user: user)
     user.create_profile :name => 'tmm1', :homepage => 'https://github.com/tmm1'
 
     github = Domain.create! :host => 'github.com'
@@ -143,18 +140,17 @@ class ActiveRecordTest < Minitest::Test
     assert_equal 2, objects.size
 
     type, id, attrs, obj = objects.shift
-    assert_equal 'Profile', type
-    assert_equal rtomayko.profile.id, id
-    assert_equal 'Ryan Tomayko', attrs['name']
-    assert_equal rtomayko.profile, obj
-
-    type, id, attrs, obj = objects.shift
     assert_equal 'User', type
     assert_equal rtomayko.id, id
     assert_equal 'rtomayko', attrs['login']
     assert_equal rtomayko.created_at, attrs['created_at']
     assert_equal rtomayko, obj
 
+    type, id, attrs, obj = objects.shift
+    assert_equal 'Profile', type
+    assert_equal rtomayko.profile.id, id
+    assert_equal 'Ryan Tomayko', attrs['name']
+    assert_equal rtomayko.profile, obj
   end
 
   def test_omit_dumping_of_attribute
@@ -241,19 +237,18 @@ class ActiveRecordTest < Minitest::Test
     assert_equal 3, objects.size
 
     type, id, attrs, obj = objects.shift
-    assert_equal 'Note', type
-    assert_equal note.id, id
-    assert_equal note.notable_type, attrs['notable_type']
-    assert_equal attrs["notable_id"], [:id, 'User', rtomayko.id]
-    assert_equal note, obj
-
-    type, id, attrs, obj = objects.shift
     assert_equal 'User', type
     assert_equal rtomayko.id, id
 
     type, id, attrs, obj = objects.shift
     assert_equal 'Profile', type
 
+    type, id, attrs, obj = objects.shift
+    assert_equal 'Note', type
+    assert_equal note.id, id
+    assert_equal note.notable_type, attrs['notable_type']
+    assert_equal attrs["notable_id"], [:id, 'User', rtomayko.id]
+    assert_equal note, obj
   end
 
   def test_dumping_has_many_associations
@@ -400,12 +395,12 @@ class ActiveRecordTest < Minitest::Test
     @dumper.dump note
 
     assert_equal 2, objects.size
-    type, id, attrs, obj = objects.shift
-    assert_equal 'Note', type
 
     type, id, attrs, obj = objects.shift
     assert_equal 'User::Namespaced', type
 
+    type, id, attrs, obj = objects.shift
+    assert_equal 'Note', type
   end
 
   def test_skips_belongs_to_information_if_omitted

--- a/test/dumper_test.rb
+++ b/test/dumper_test.rb
@@ -44,23 +44,6 @@ class DumperTest < Minitest::Test
     assert called
   end
 
-  def test_never_dumps_objects_more_than_once_for_root_class
-    called = false
-    object = thing('name' => 'thing', 'test' => 'value1')
-    object2 = thing('name' => 'thing', 'test' => 'value2')
-    @dumper = Replicate::Dumper.new(nil, Replicate::Object)
-    @dumper.listen do |type, id, attrs, obj|
-      assert !called
-      called = true
-    end
-
-    @dumper.dump object
-    @dumper.dump object
-    @dumper.dump object
-    @dumper.dump object2
-    assert called
-  end
-
   # This test currently fails. It's been a long time since anybody
   # worked on this library and I'm not sure if it's just because of
   # a Ruby update or what. In any event I'm just going to comment it out


### PR DESCRIPTION
Reverts norman/replicate#1

I noticed errors when replicating records with `belongs_to` relationships after this was merged. I don't have a detailed but report yet but will try to add some more information soon.